### PR TITLE
Fix dependencies section in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add required dependencies. You'll need at least `stargate-grpc` and an async fra
 e.g. tokio:
 
 ```toml
-[dev-dependencies]
+[dependencies]
 stargate-grpc = { git = "https://github.com/stargate/stargate-grpc-rust-client" }
 tokio = { version = "1", features = ["full"]}
 ```


### PR DESCRIPTION
### Summary

Fixes minor typo in the quick start section of the readme. 
`devependencies` -> `dependencies`