### PR TITLE
Support converting to/from tuples of size 1

### DIFF
--- a/stargate-grpc/Cargo.toml
+++ b/stargate-grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stargate-grpc"
 description = "gRPC client for Stargate"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 homepage = "https://github.com/stargate/stargate-grpc-rust-client"
 repository = "https://github.com/stargate/stargate-grpc-rust-client"

--- a/stargate-grpc/src/query.rs
+++ b/stargate-grpc/src/query.rs
@@ -439,3 +439,70 @@ impl ValuesBuilder {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::proto::Values;
+    use crate::query::ValuesBuilder;
+    use crate::Value;
+
+    #[test]
+    fn bind_a_single_item_tuple() {
+        let mut builder = ValuesBuilder::default();
+        builder.bind((1,));
+        let values = builder.build();
+        assert_eq!(
+            values,
+            Some(Values {
+                values: vec![Value::int(1)],
+                value_names: vec![]
+            })
+        )
+    }
+
+    #[test]
+    fn bind_a_tuple() {
+        let mut builder = ValuesBuilder::default();
+        builder.bind((1, 2.0, "foo"));
+        let values = builder.build();
+        assert_eq!(
+            values,
+            Some(Values {
+                values: vec![Value::int(1), Value::double(2.0), Value::string("foo")],
+                value_names: vec![]
+            })
+        )
+    }
+
+    #[test]
+    fn bind_ith() {
+        let mut builder = ValuesBuilder::default();
+        builder.bind_ith(0, 1);
+        builder.bind_ith(1, 2.0);
+        builder.bind_ith(2, "foo");
+        let values = builder.build();
+        assert_eq!(
+            values,
+            Some(Values {
+                values: vec![Value::int(1), Value::double(2.0), Value::string("foo")],
+                value_names: vec![]
+            })
+        )
+    }
+
+    #[test]
+    fn bind_name() {
+        let mut builder = ValuesBuilder::default();
+        builder.bind_name("a", 1);
+        builder.bind_name("b", 2.0);
+        builder.bind_name("c", "foo");
+        let values = builder.build();
+        assert_eq!(
+            values,
+            Some(Values {
+                values: vec![Value::int(1), Value::double(2.0), Value::string("foo")],
+                value_names: vec!["a".to_string(), "b".to_string(), "c".to_string()]
+            })
+        );
+    }
+}


### PR DESCRIPTION
Rust allows to create a tuple of size 1 by using
a trailing comma syntax:

```rust
let tuple = (1,);  // a tuple holding a single value
```

So far we only generated tuple conversions for tuples with
at least 2 items, so single-column Rows obtained in result sets
had to be handled differently than N-column Rows.

After this patch, the user will be able to extract the value
from a single column row the same way as it was possible with
multi-column rows:

```rust
let row: Row = // obtain the row from the ResultSet
let (value,): (u64,) = row.try_into().unwrap();
```

Similarly, it is possible to bind a single value in query
with bind:

```rust
let query = Query::builder()
     .keyspace("ks")
     .consistency(Consistency::LocalQuorum)
     .query("SELECT * FROM table WHERE year = :year")
     .bind((2021,))
     .build();
```

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)

Documentation update not needed because
the limitation removed by this patch was never documented.